### PR TITLE
Fix JSON syntax error in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
     },
     "autoload": {
         "psr-4": {
-            "Geocoder\\": "src/Geocoder",
+            "Geocoder\\": "src/Geocoder"
         }
     }
 }


### PR DESCRIPTION
This is breaking the `composer drupal-update` command, there's a trailing comma in composer.json.