### PR TITLE
Reverse Geocode implementation and many bug fixes and_enanchments for geocoder submodules.

### DIFF
--- a/geocoder.services.yml
+++ b/geocoder.services.yml
@@ -14,6 +14,7 @@ services:
   plugin.manager.geocoder.dumper:
     class: Drupal\geocoder\DumperPluginManager
     parent: default_plugin_manager
+    arguments: ['@logger.factory']
 
   plugin.manager.geocoder.formatter:
     class: Drupal\geocoder\FormatterPluginManager

--- a/modules/geocoder_address/src/Plugin/Geocoder/Field/AddressField.php
+++ b/modules/geocoder_address/src/Plugin/Geocoder/Field/AddressField.php
@@ -45,7 +45,6 @@ class AddressField extends DefaultField {
         '#type' => 'value',
         '#value' => 'geojson',
       ];
-
     }
 
     return $element;

--- a/modules/geocoder_address/src/Plugin/Geocoder/Field/AddressField.php
+++ b/modules/geocoder_address/src/Plugin/Geocoder/Field/AddressField.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace Drupal\geocoder_address\Plugin\Geocoder\Field;
+
+use Drupal\Core\Field\FieldConfigInterface;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\geocoder_field\Plugin\Geocoder\Field\DefaultField;
+
+/**
+ * Provides a Geocoder Address field plugin.
+ *
+ * @GeocoderField(
+ *   id = "address_field",
+ *   label = @Translation("Address field plugin"),
+ *   field_types = {
+ *     "address"
+ *   }
+ * )
+ */
+class AddressField extends DefaultField {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getSettingsForm(FieldConfigInterface $field, array $form, FormStateInterface &$form_state) {
+    $element = parent::getSettingsForm($field, $form, $form_state);
+
+    // The Address Field can just be object of Reverse Geocoding.
+    $element['method']['#options'] = [
+      'none' => $this->t('No geocoding'),
+    ];
+
+    $reverse_geocode_source_fields_options = $this->fieldPluginManager->getReverseGeocodeSourceFields($field->getTargetEntityTypeId(), $field->getTargetBundle(), $field->getName());
+
+    // If the Geocoder Geofield Module exists and there is at least one
+    // geofield defined from the entity, extend the Form with Reverse Geocode
+    // (from Geofield) capabilities.
+    if (!empty($reverse_geocode_source_fields_options) && $this->moduleHandler->moduleExists('geocoder_geofield')) {
+
+      // Add the Option to Reverse Geocode.
+      $element['method']['#options']['destination'] = $this->t('<b>Reverse Geocode</b> from a Geofield type existing field');
+
+      // On Address Field the dumper should always be 'geometry'.
+      $element['dumper'] = [
+        '#type' => 'value',
+        '#value' => 'geojson',
+      ];
+
+    }
+
+    return $element;
+  }
+
+}

--- a/modules/geocoder_field/config.rb
+++ b/modules/geocoder_field/config.rb
@@ -1,0 +1,5 @@
+http_path = "/"
+css_dir = "css"
+sass_dir = "sass"
+images_dir = "images"
+javascripts_dir = "js"

--- a/modules/geocoder_field/css/geocoder_field_general.css
+++ b/modules/geocoder_field/css/geocoder_field_general.css
@@ -1,0 +1,13 @@
+/* line 2, ../sass/geocoder_field_general.scss */
+table#edit-third-party-settings-geocoder-field-plugins .form-item input.error {
+  outline: solid red thin;
+}
+
+/* line 6, ../sass/geocoder_field_general.scss */
+#field-display-overview .field-plugin-settings-edit-form table.geocode-formatter .form-item {
+  margin: 0;
+}
+/* line 8, ../sass/geocoder_field_general.scss */
+#field-display-overview .field-plugin-settings-edit-form table.geocode-formatter .form-item input.error {
+  outline: solid red thin;
+}

--- a/modules/geocoder_field/geocoder_field.libraries.yml
+++ b/modules/geocoder_field/geocoder_field.libraries.yml
@@ -1,0 +1,5 @@
+general:
+  version: 1.x
+  css:
+    component:
+      css/geocoder_field_general.css: {}

--- a/modules/geocoder_field/geocoder_field.module
+++ b/modules/geocoder_field/geocoder_field.module
@@ -114,6 +114,7 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
   /** @var \Drupal\geocoder\DumperPluginManager $dumper_manager */
   $dumper_manager = \Drupal::service('plugin.manager.geocoder.dumper');
 
+  // Reorder the list of fields to be Geocoded | Reverse Geocoded.
   $order_geocoder_fields = $preprocessor_manager->getOrderedGeocodeFields($entity);
 
   foreach ($order_geocoder_fields as $field_name => $field) {

--- a/modules/geocoder_field/geocoder_field.module
+++ b/modules/geocoder_field/geocoder_field.module
@@ -48,10 +48,8 @@ function geocoder_field_form_alter(array &$form, FormStateInterface $form_state,
  * Implements hook_form_FORM_ID_alter().
  */
 function geocoder_field_form_field_config_edit_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
-  /* @var \Drupal\Core\Entity\EntityForm $entity_form */
-  $entity_form = $form_state->getFormObject();
   /** @var \Drupal\Core\Field\FieldConfigInterface $field */
-  $field = $entity_form->getEntity();
+  $field = $form_state->getFormObject()->getEntity();
   /** @var \Drupal\geocoder_field\GeocoderFieldPluginInterface $field_plugin */
   if (!$field_plugin = \Drupal::service('geocoder_field.plugin.manager.field')->getPluginByFieldType($field->getType())) {
     // There's no geocoding field plugin to handle this type of field.
@@ -161,12 +159,12 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
         /* @var \Geocoder\Model\AddressCollection $address_collection */
         switch ($geocoder['method']) {
           case 'source':
-            $failure_status_message = t("'@text' cannot be Geocoded.", ['@text' => $value['value']]);
+            $failure_status_message = t("Unable to Geocode '@text'.", ['@text' => $value['value']]);
             $address_collection = \Drupal::service('geocoder')->geocode($value['value'], $geocoder['plugins']);
             break;
 
           case 'destination':
-            $failure_status_message = t("'@text' cannot be Reverse Geocoded.", ['@text' => $value['value']]);
+            $failure_status_message = t("Unable to Reverse Geocode '@text'.", ['@text' => $value['value']]);
             $address_collection = \Drupal::service('geocoder')->reverse($value['lat'], $value['lon'], $geocoder['plugins']);
             break;
 
@@ -174,9 +172,7 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
         }
 
         if ($address_collection) {
-
           switch ($geocoder['delta_handling']) {
-
             // Single-to-multiple handling - if we can, explode out the
             // component geometries.
             case 's_to_m':
@@ -202,9 +198,7 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
                 $result[$delta] = $dumper_manager->setAddressFieldFromGeojson($result[$delta]);
               }
           }
-
           continue;
-
         }
         if ($geocoder['failure']['handling'] == 'preserve') {
           $result[$delta] = isset($default_values[$delta]) ? $default_values[$delta]->getValue() : NULL;

--- a/modules/geocoder_field/geocoder_field.module
+++ b/modules/geocoder_field/geocoder_field.module
@@ -165,8 +165,9 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
             break;
 
           case 'destination':
-            $failure_status_message = t("Unable to Reverse Geocode '@text'.", ['@text' => $value['value']]);
-            $address_collection = \Drupal::service('geocoder')->reverse($value['lat'], $value['lon'], $geocoder['plugins']);
+            $failure_status_message = t("Unable to Reverse Geocode the '@field_name' value.", ['@field_name' => $field_name]);
+            $address_collection = isset($value['lat']) && isset($value['lon']) ? \Drupal::service('geocoder')->reverse($value['lat'], $value['lon'], $geocoder['plugins']) : NULL;
+
             break;
 
           default:

--- a/modules/geocoder_field/geocoder_field.module
+++ b/modules/geocoder_field/geocoder_field.module
@@ -10,13 +10,48 @@ use Drupal\Core\Entity\EntityInterface;
 use Drupal\Core\Field\FieldConfigInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Core\Form\FormState;
+use Drupal\Core\Entity\ContentEntityFormInterface;
+
+/**
+ * Implements hook_form_alter().
+ *
+ * Eventually Disable or Hide Geocode Fields.
+ */
+function geocoder_field_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  if ($form_state->getFormObject() instanceof ContentEntityFormInterface) {
+    /* @var \Drupal\Core\Entity\EntityForm $entity_form */
+    $entity_form = $form_state->getFormObject();
+    /* @var \Drupal\Core\Entity\ContentEntityInterface $entity */
+    $entity = $entity_form->getEntity();
+    foreach ($entity->getFields() as $field_name => $field) {
+      /** @var \Drupal\Core\Field\FieldConfigInterface $field_config */
+      if (!($field_config = $field->getFieldDefinition()) instanceof FieldConfigInterface) {
+        // Only configurable fields are subject of geocoding.
+        continue;
+      }
+      // Eventually Disable the Geocoded Field.
+      $geocoder = $field_config->getThirdPartySettings('geocoder_field');
+      if (isset($geocoder['method']) && $geocoder['method'] !== 'none') {
+        if (isset($geocoder['disabled']) && $geocoder['disabled'] == TRUE) {
+          $form[$field_name]['#disabled'] = TRUE;
+        }
+        // Eventually Hide the Geocoded Field.
+        if (isset($geocoder['hidden']) && $geocoder['hidden'] == TRUE) {
+          $form[$field_name]['#access'] = FALSE;
+        }
+      }
+    }
+  }
+}
 
 /**
  * Implements hook_form_FORM_ID_alter().
  */
 function geocoder_field_form_field_config_edit_form_alter(array &$form, FormStateInterface $form_state, $form_id) {
+  /* @var \Drupal\Core\Entity\EntityForm $entity_form */
+  $entity_form = $form_state->getFormObject();
   /** @var \Drupal\Core\Field\FieldConfigInterface $field */
-  $field = $form_state->getFormObject()->getEntity();
+  $field = $entity_form->getEntity();
   /** @var \Drupal\geocoder_field\GeocoderFieldPluginInterface $field_plugin */
   if (!$field_plugin = \Drupal::service('geocoder_field.plugin.manager.field')->getPluginByFieldType($field->getType())) {
     // There's no geocoding field plugin to handle this type of field.
@@ -56,6 +91,9 @@ function geocoder_field_field_config_edit_form_validate(array $form, FormStateIn
   /** @var \Drupal\geocoder_field\GeocoderFieldPluginInterface $field_plugin */
   $field_plugin = $form_state->getValue($trail);
   $field_plugin->validateSettingsForm($form, $geocoder_data);
+  // Update the $form_state with the $geocoder_data possibly altered in the
+  // validateSettingsForm method.
+  $form_state->setValue(['third_party_settings', 'geocoder_field'], $geocoder_data->getValues());
   // Copy back any error.
   foreach ($geocoder_data->getErrors() as $name => $error) {
     $form_state->setErrorByName($name, $error);
@@ -75,9 +113,12 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
 
   /** @var \Drupal\geocoder_field\PreprocessorPluginManager $preprocessor_manager */
   $preprocessor_manager = \Drupal::service('plugin.manager.geocoder.preprocessor');
+  /** @var \Drupal\geocoder\DumperPluginManager $dumper_manager */
   $dumper_manager = \Drupal::service('plugin.manager.geocoder.dumper');
 
-  foreach ($entity->getFields() as $field_name => $field) {
+  $order_geocoder_fields = $preprocessor_manager->getOrderedGeocodeFields($entity);
+
+  foreach ($order_geocoder_fields as $field_name => $field) {
     /** @var \Drupal\Core\Field\FieldConfigInterface $field_config */
     if (!($field_config = $field->getFieldDefinition()) instanceof FieldConfigInterface) {
       // Only configurable fields are subject of geocoding.
@@ -85,63 +126,104 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
     }
     $geocoder = $field_config->getThirdPartySettings('geocoder_field');
     if (empty($geocoder['method']) || $geocoder['method'] === 'none') {
-      // This field was not configured to geocode from/to other field.
+      // This field was not configured to geocode/reverse_geocode from/to
+      // other field.
       continue;
     }
 
-    // @todo [cc]: Check here for malformed $geocode and throw exceptions.
-    $remote_field = $entity->get($geocoder['field']);
-    if (empty($remote_field->getValue())) {
-      if ($geocoder['failure']['handling'] == 'preserve') {
+    switch ($geocoder['method']) {
+      case 'source':
+        $remote_field = $entity->get($geocoder['geocode_field']);
+        break;
+
+      case 'destination':
+        $remote_field = $entity->get($geocoder['reverse_geocode_field']);
+        break;
+
+      default:
+    }
+
+    if (isset($remote_field)) {
+      if (empty($remote_field->getValue()) && $geocoder['failure']['handling'] == 'preserve') {
         return;
       }
-    }
 
-    // Pre-process field.
-    $preprocessor_manager->preprocess($remote_field);
+      // Pre-process field.
+      $preprocessor_manager->preprocess($remote_field);
 
-    /** @var \Drupal\geocoder\DumperInterface $dumper */
-    $dumper = $dumper_manager->createInstance($geocoder['dumper']);
+      /** @var \Drupal\geocoder\DumperInterface|\Drupal\Component\Plugin\PluginInspectionInterface $dumper */
+      $dumper = $dumper_manager->createInstance($geocoder['dumper']);
+      $default_values = $entity->get($field_name);
+      $result = [];
+      $failure_status_message = '';
 
-    $default_values = $entity->get($field_name);
-    $result = [];
-    foreach ($remote_field->getValue() as $delta => $value) {
-      if ($address_collection = \Drupal::service('geocoder')->geocode($value['value'], $geocoder['plugins'])) {
+      foreach ($remote_field->getValue() as $delta => $value) {
         /* @var \Geocoder\Model\AddressCollection $address_collection */
-
-        switch ($geocoder['delta_handling']) {
-
-          // Single-to-multiple handling - if we can, explode out the
-          // component geometries.
-          case 's_to_m':
-            foreach ($address_collection->all() as $collectionDelta => $address) {
-              $result[$collectionDelta] = $dumper->dump($address);
-            }
+        switch ($geocoder['method']) {
+          case 'source':
+            $failure_status_message = t("'@text' cannot be Geocoded.", ['@text' => $value['value']]);
+            $address_collection = \Drupal::service('geocoder')->geocode($value['value'], $geocoder['plugins']);
             break;
 
-          // Default delta handling: just pass one delta to the next.
+          case 'destination':
+            $failure_status_message = t("'@text' cannot be Reverse Geocoded.", ['@text' => $value['value']]);
+            $address_collection = \Drupal::service('geocoder')->reverse($value['lat'], $value['lon'], $geocoder['plugins']);
+            break;
+
           default:
-            $result[$delta] = $dumper->dump($address_collection->first());
         }
 
-        continue;
+        if ($address_collection) {
 
+          switch ($geocoder['delta_handling']) {
+
+            // Single-to-multiple handling - if we can, explode out the
+            // component geometries.
+            case 's_to_m':
+              foreach ($address_collection->all() as $collection_delta => $address) {
+                $result[] = $dumper->dump($address);
+                // Check|Fix some incompatibility between Dumper output and
+                // Field Config.
+                $dumper_manager->fixDumperFieldIncompatibility($result[$delta], $dumper, $field_config);
+              }
+              break;
+
+            // Default delta handling: just pass one delta to the next.
+            default:
+              $result[$delta] = $dumper->dump($address_collection->first());
+
+              // Check|Fix some incompatibility between Dumper output and
+              // Field Config.
+              $dumper_manager->fixDumperFieldIncompatibility($result[$delta], $dumper, $field_config);
+
+              // If an Address field is being processed, transform its Dumper
+              // string result into array to comply to Address entity->set Api.
+              if ($geocoder['method'] == 'destination' && $field_config->getType() == 'address' && $dumper->getPluginId() == 'geojson') {
+                $result[$delta] = $dumper_manager->setAddressFieldFromGeojson($result[$delta]);
+              }
+          }
+
+          continue;
+
+        }
+        if ($geocoder['failure']['handling'] == 'preserve') {
+          $result[$delta] = isset($default_values[$delta]) ? $default_values[$delta]->getValue() : NULL;
+        }
+        elseif ($geocoder['failure']['handling'] == 'empty') {
+          $result[$delta] = NULL;
+        }
+        // Display a status message.
+        if ($geocoder['failure']['status_message']) {
+          drupal_set_message($failure_status_message, 'warning');
+        }
+        // Log the failure.
+        if ($geocoder['failure']['log']) {
+          \Drupal::logger('geocoder')
+            ->warning($failure_status_message);
+        }
       }
-      if ($geocoder['failure']['handling'] == 'preserve') {
-        $result[$delta] = isset($default_values[$delta]) ? $default_values[$delta]->getValue() : NULL;
-      }
-      elseif ($geocoder['failure']['handling'] == 'empty') {
-        $result[$delta] = NULL;
-      }
-      // Display a status message.
-      if ($geocoder['failure']['status_message']) {
-        drupal_set_message(t("'@text' cannot be geocoded.", ['@text' => $value['value']]), 'warning');
-      }
-      // Log the failure.
-      if ($geocoder['failure']['log']) {
-        \Drupal::logger('geocoder')->warning(t("'@text' cannot be geocoded.", ['@text' => $value['value']]));
-      }
+      $entity->set($field_name, $result);
     }
-    $entity->set($field_name, $result);
   }
+
 }

--- a/modules/geocoder_field/sass/geocoder_field_general.scss
+++ b/modules/geocoder_field/sass/geocoder_field_general.scss
@@ -1,0 +1,11 @@
+
+table#edit-third-party-settings-geocoder-field-plugins .form-item input.error {
+  outline: solid red thin;
+}
+
+#field-display-overview .field-plugin-settings-edit-form table.geocode-formatter .form-item {
+  margin: 0;
+  input.error {
+    outline: solid red thin;
+  }
+}

--- a/modules/geocoder_field/src/GeocoderFieldPluginManager.php
+++ b/modules/geocoder_field/src/GeocoderFieldPluginManager.php
@@ -43,7 +43,13 @@ class GeocoderFieldPluginManager extends DefaultPluginManager {
    * @param \Drupal\Core\Entity\EntityFieldManagerInterface $entity_field_manager
    *   The entity field manager service.
    */
-  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler, PreprocessorPluginManager $preprocessor_plugin_manager, EntityFieldManagerInterface $entity_field_manager) {
+  public function __construct(
+    \Traversable $namespaces,
+    CacheBackendInterface $cache_backend,
+    ModuleHandlerInterface $module_handler,
+    PreprocessorPluginManager $preprocessor_plugin_manager,
+    EntityFieldManagerInterface $entity_field_manager
+  ) {
     parent::__construct('Plugin/Geocoder/Field', $namespaces, $module_handler, GeocoderFieldPluginInterface::class, GeocoderField::class);
     $this->alterInfo('geocode_field_info');
     $this->setCacheBackend($cache_backend, 'geocode_field_plugins');

--- a/modules/geocoder_field/src/GeocoderFieldPluginManager.php
+++ b/modules/geocoder_field/src/GeocoderFieldPluginManager.php
@@ -53,6 +53,36 @@ class GeocoderFieldPluginManager extends DefaultPluginManager {
   }
 
   /**
+   * Get Fields Options.
+   *
+   * @param string $entity_type_id
+   *   The entity type id.
+   * @param string $bundle
+   *   The bundle.
+   * @param string $field_name
+   *   The field name.
+   * @param array $field_types
+   *   The field types array.
+   *
+   * @return mixed
+   *   The options results.
+   */
+  private function getFieldsOptions($entity_type_id, $bundle, $field_name, array $field_types) {
+    $options = [];
+    foreach ($this->entityFieldManager->getFieldDefinitions($entity_type_id, $bundle) as $id => $definition) {
+      if (in_array($definition->getType(), $field_types) && ($definition->getName()) !== $field_name) {
+        $options[$id] = new TranslatableMarkup(
+          '@label (@name) [@type]', [
+            '@label' => $definition->getLabel(),
+            '@name' => $definition->getName(),
+            '@type' => $definition->getType(),
+          ]);
+      }
+    }
+    return $options;
+  }
+
+  /**
    * Returns the first plugin that handles a specific field type.
    *
    * @param string $field_type
@@ -86,21 +116,8 @@ class GeocoderFieldPluginManager extends DefaultPluginManager {
    *   The array of source fields and their label.
    */
   public function getGeocodeSourceFields($entity_type_id, $bundle, $field_name) {
-    $options = [];
-
-    $types = $this->preprocessorPluginManager->getGeocodeSourceFieldsTypes();
-
-    foreach ($this->entityFieldManager->getFieldDefinitions($entity_type_id, $bundle) as $id => $definition) {
-      if (in_array($definition->getType(), $types) && ($definition->getName()) !== $field_name) {
-        $options[$id] = new TranslatableMarkup(
-          '@label (@name) [@type]', [
-            '@label' => $definition->getLabel(),
-            '@name' => $definition->getName(),
-            '@type' => $definition->getType(),
-          ]);
-      }
-    }
-
+    $field_types = $this->preprocessorPluginManager->getGeocodeSourceFieldsTypes();
+    $options = $this->getFieldsOptions($entity_type_id, $bundle, $field_name, $field_types);
     return $options;
   }
 
@@ -118,20 +135,8 @@ class GeocoderFieldPluginManager extends DefaultPluginManager {
    *   The array of source fields and their label.
    */
   public function getReverseGeocodeSourceFields($entity_type_id, $bundle, $field_name) {
-    $options = [];
-
-    $types = $this->preprocessorPluginManager->getReverseGeocodeSourceFieldsTypes();
-
-    foreach ($this->entityFieldManager->getFieldDefinitions($entity_type_id, $bundle) as $id => $definition) {
-      if (in_array($definition->getType(), $types) && ($definition->getName()) !== $field_name) {
-        $options[$id] = new TranslatableMarkup(
-          '@label (@name) [@type]', [
-            '@label' => $definition->getLabel(),
-            '@name' => $definition->getName(),
-            '@type' => $definition->getType(),
-          ]);
-      }
-    }
+    $field_types = $this->preprocessorPluginManager->getReverseGeocodeSourceFieldsTypes();
+    $options = $this->getFieldsOptions($entity_type_id, $bundle, $field_name, $field_types);
     return $options;
   }
 

--- a/modules/geocoder_field/src/Plugin/Field/GeocodeFormatterBase.php
+++ b/modules/geocoder_field/src/Plugin/Field/GeocodeFormatterBase.php
@@ -92,9 +92,9 @@ abstract class GeocodeFormatterBase extends FormatterBase implements ContainerFa
    */
   public static function defaultSettings() {
     return parent::defaultSettings() + array(
-        'dumper_plugin' => 'wkt',
-        'provider_plugins' => array(),
-      );
+      'dumper_plugin' => 'wkt',
+      'provider_plugins' => array(),
+    );
   }
 
   /**
@@ -102,6 +102,11 @@ abstract class GeocodeFormatterBase extends FormatterBase implements ContainerFa
    */
   public function settingsForm(array $form, FormStateInterface $form_state) {
     $elements = parent::settingsForm($form, $form_state);
+
+    // Attach Geofield Map Library.
+    $elements['#attached']['library'] = [
+      'geocoder_field/general',
+    ];
 
     $enabled_plugins = array();
     $i = 0;
@@ -134,6 +139,12 @@ abstract class GeocodeFormatterBase extends FormatterBase implements ContainerFa
           'group' => 'provider_plugins-order-weight',
         ),
       ),
+      '#attributes' => [
+        'class' => [
+          'geocode-formatter',
+        ],
+      ],
+      '#element_validate' => array([get_class($this), 'validateGeocodeFormatterPlugins']),
     );
 
     $rows = array();
@@ -244,6 +255,23 @@ abstract class GeocodeFormatterBase extends FormatterBase implements ContainerFa
     }
 
     return $provider_plugin_ids;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function validateGeocodeFormatterPlugins(array $element, FormStateInterface &$form_state) {
+    $plugins = [];
+    $element_values_array = $element['#value'];
+    foreach ($element_values_array as $k => $value) {
+      if (isset($value['checked']) && $value['checked'] == '1') {
+        $plugins[] = $k;
+      }
+    }
+
+    if (empty($plugins)) {
+      $form_state->setError($element, t('The Geocoder operation chosen needs at least one Plugin to be selected.'));
+    }
   }
 
 }

--- a/modules/geocoder_field/src/Plugin/Field/GeocodeFormatterBase.php
+++ b/modules/geocoder_field/src/Plugin/Field/GeocodeFormatterBase.php
@@ -262,8 +262,7 @@ abstract class GeocodeFormatterBase extends FormatterBase implements ContainerFa
    */
   public static function validateGeocodeFormatterPlugins(array $element, FormStateInterface &$form_state) {
     $plugins = [];
-    $element_values_array = $element['#value'];
-    foreach ($element_values_array as $k => $value) {
+    foreach ($element['#value'] as $k => $value) {
       if (isset($value['checked']) && $value['checked'] == '1') {
         $plugins[] = $k;
       }

--- a/modules/geocoder_field/src/Plugin/Geocoder/Field/DefaultField.php
+++ b/modules/geocoder_field/src/Plugin/Geocoder/Field/DefaultField.php
@@ -327,7 +327,7 @@ class DefaultField extends PluginBase implements GeocoderFieldPluginInterface, C
     $form_values = $form_state->getValues();
 
     if ($form_values['method'] !== 'none' && empty($form_values['plugins'])) {
-      $form_state->setError($form['third_party_settings']['geocoder_field']['plugins'], t('The Geocoder operation chosen needs at least one Plugin to be selected.'));
+      $form_state->setError($form['third_party_settings']['geocoder_field']['plugins'], t('The selected Geocode operation needs at least one plugin.'));
     }
 
     // On Reverse Geocode the delta_handling should always be 'default'

--- a/modules/geocoder_field/src/PreprocessorPluginManager.php
+++ b/modules/geocoder_field/src/PreprocessorPluginManager.php
@@ -52,11 +52,9 @@ class PreprocessorPluginManager extends GeocoderPluginManagerBase {
   }
 
   /**
-   * Provides a reordered list of Geocoder set fields.
+   * Get the ordered list of fields to be Geocoded | Reverse Geocoded.
    *
-   * This lists before the reverse geocode and than the geocode fields so that
-   * to implement a correct incremental combination of both operations in the
-   * entity presave.
+   * Reorders the fields based on the user-defined GeocoderField weights.
    *
    * @param \Drupal\Core\Entity\ContentEntityInterface $entity
    *   The Entity that needs to be preprocessed.

--- a/modules/geocoder_geofield/src/Plugin/Geocoder/Field/GeofieldField.php
+++ b/modules/geocoder_geofield/src/Plugin/Geocoder/Field/GeofieldField.php
@@ -24,11 +24,19 @@ class GeofieldField extends DefaultField {
    */
   public function getSettingsForm(FieldConfigInterface $field, array $form, FormStateInterface &$form_state) {
     $element = parent::getSettingsForm($field, $form, $form_state);
-    // On geofield the dumper is always 'wkt'.
+
+    // The Geofield can just be object of Geocoding.
+    $element['method']['#options'] = [
+      'none' => $this->t('No geocoding'),
+      'source' => $this->t('<b>Geocode</b> from an existing field'),
+    ];
+
+    // On Geofield the dumper should always be 'wkt'.
     $element['dumper'] = [
       '#type' => 'value',
       '#value' => 'wkt',
     ];
+
     return $element;
   }
 

--- a/src/DumperPluginManager.php
+++ b/src/DumperPluginManager.php
@@ -5,11 +5,18 @@ namespace Drupal\geocoder;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\geocoder\Annotation\GeocoderDumper;
+use Drupal\Component\Serialization\Json;
+use Drupal\Core\Field\FieldConfigInterface;
 
 /**
  * Provides a plugin manager for geocoder dumpers.
  */
 class DumperPluginManager extends GeocoderPluginManagerBase {
+
+  private $maxLengthFieldTypes = [
+    "text",
+    "string",
+  ];
 
   /**
    * {@inheritdoc}
@@ -18,6 +25,69 @@ class DumperPluginManager extends GeocoderPluginManagerBase {
     parent::__construct('Plugin/Geocoder/Dumper', $namespaces, $module_handler, DumperInterface::class, GeocoderDumper::class);
     $this->alterInfo('geocoder_dumper_info');
     $this->setCacheBackend($cache_backend, 'geocoder_dumper_plugins');
+  }
+
+  /**
+   * Define an Address field value from a Geojson string.
+   *
+   * @param string $geojson
+   *   The GeoJson place string.
+   *
+   * @return array
+   *   An array of the Address field value.
+   */
+  public function setAddressFieldFromGeojson($geojson) {
+    $geojson_array = Json::decode($geojson);
+
+    $address_field_value = [
+      'country_code' => isset($geojson_array['properties']['countryCode']) ? substr($geojson_array['properties']['countryCode'], 0, 2) : '',
+      'address_line1' => isset($geojson_array['properties']['streetName']) ? $geojson_array['properties']['streetName'] : '',
+      'postal_code' => isset($geojson_array['properties']['postalCode']) ? $geojson_array['properties']['postalCode'] : '',
+      'locality' => isset($geojson_array['properties']['locality']) ? $geojson_array['properties']['locality'] : '',
+    ];
+
+    return $address_field_value;
+
+  }
+
+  /**
+   * Check|Fix some incompatibility between Dumper output and Field Config.
+   *
+   * @param string $dumper_result
+   *   The Dumper result string.
+   * @param \Drupal\geocoder\DumperInterface|\Drupal\Component\Plugin\PluginInspectionInterface $dumper
+   *   The Dumper.
+   * @param \Drupal\Core\Field\FieldConfigInterface $field_config
+   *   The Field Configuration.
+   */
+  public function fixDumperFieldIncompatibility(&$dumper_result, $dumper, FieldConfigInterface $field_config) {
+
+    // Fix not UTF-8 encoded result strings.
+    // https://stackoverflow.com/questions/6723562/how-to-detect-malformed-utf-8-string-in-php
+    if (!preg_match('//u', $dumper_result)) {
+      $dumper_result = utf8_encode($dumper_result);
+    }
+
+    // If the field is a string|text type check if the result length is
+    // compatible with its max_length definition, otherwise truncate it and
+    // set | log a warning message.
+    if (in_array($field_config->getType(), $this->maxLengthFieldTypes) &&
+      strlen($dumper_result) > $field_config->getFieldStorageDefinition()->getSetting('max_length')) {
+
+      $incompatibility_warning_message = t("The '@field_name' field 'max length' property is not compatible with the chosen '@dumper' dumper.<br>Thus <b>be aware</b> <u>the dumper output result has been truncated to @max_length chars (max length)</u>.<br> You are advised to change the '@field_name' field definition or chose another compatible dumper.", [
+        '@field_name' => $field_config->getLabel(),
+        '@dumper' => $dumper->getPluginId(),
+        '@max_length' => $field_config->getFieldStorageDefinition()->getSetting('max_length'),
+      ]);
+
+      $dumper_result = substr($dumper_result, 0, $field_config->getFieldStorageDefinition()->getSetting('max_length'));
+
+      // Display a max-length incompatibility warning message.
+      drupal_set_message($incompatibility_warning_message, 'warning');
+
+      // Log the max-length incompatibility.
+      \Drupal::logger('geocoder')->warning($incompatibility_warning_message);
+    }
   }
 
 }

--- a/src/FormatterPluginManager.php
+++ b/src/FormatterPluginManager.php
@@ -2,7 +2,7 @@
 
 namespace Drupal\geocoder;
 
-use Drupal\geocoder\Plugin\Geocoder\Formatter\GeocoderFormatterInterface;
+use Drupal\geocoder\Plugin\Geocoder\Formatter\FormatterInterface;
 use Drupal\Core\Cache\CacheBackendInterface;
 use Drupal\Core\Extension\ModuleHandlerInterface;
 use Drupal\geocoder\Annotation\GeocoderFormatter;
@@ -16,7 +16,7 @@ class FormatterPluginManager extends GeocoderPluginManagerBase {
    * {@inheritdoc}
    */
   public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
-    parent::__construct('Plugin/Geocoder/Formatter', $namespaces, $module_handler, GeocoderFormatterInterface::class, GeocoderFormatter::class);
+    parent::__construct('Plugin/Geocoder/Formatter', $namespaces, $module_handler, FormatterInterface::class, GeocoderFormatter::class);
     $this->alterInfo('geocoder_formatter_info');
     $this->setCacheBackend($cache_backend, 'geocoder_formatter_plugins');
   }

--- a/src/GeocoderPluginManagerBase.php
+++ b/src/GeocoderPluginManagerBase.php
@@ -10,6 +10,27 @@ use Drupal\Core\Plugin\DefaultPluginManager;
 abstract class GeocoderPluginManagerBase extends DefaultPluginManager {
 
   /**
+   * List of fields types available as source for Geocode operations.
+   *
+   * @var array
+   */
+  protected $geocodeSourceFieldsTypes = [
+    "string",
+    "text",
+    "text_long",
+    "address",
+  ];
+
+  /**
+   * List of fields types available as source for Reverse Geocode operations.
+   *
+   * @var array
+   */
+  protected $reverseGeocodeSourceFieldsTypes = [
+    "geofield",
+  ];
+
+  /**
    * Gets a list of available plugins to be used in forms.
    *
    * @return string[]
@@ -22,6 +43,26 @@ abstract class GeocoderPluginManagerBase extends DefaultPluginManager {
     asort($options);
 
     return $options;
+  }
+
+  /**
+   * Gets a list of fields types available for Geocode operations.
+   *
+   * @return string[]
+   *   A list of plugins in a format suitable for form API '#options' key.
+   */
+  public function getGeocodeSourceFieldsTypes() {
+    return $this->geocodeSourceFieldsTypes;
+  }
+
+  /**
+   * Gets a list of fields types available for Reverse Geocode operations.
+   *
+   * @return string[]
+   *   A list of plugins in a format suitable for form API '#options' key.
+   */
+  public function getReverseGeocodeSourceFieldsTypes() {
+    return $this->reverseGeocodeSourceFieldsTypes;
   }
 
 }

--- a/src/Plugin/Geocoder/Dumper/AddressText.php
+++ b/src/Plugin/Geocoder/Dumper/AddressText.php
@@ -27,7 +27,7 @@ class AddressText extends DumperBase {
   /**
    * The Geocoder formatter.
    *
-   * @var \Drupal\geocoder\Plugin\Geocoder\Formatter\GeocoderFormatterInterface
+   * @var \Drupal\geocoder\Plugin\Geocoder\Formatter\FormatterInterface
    */
   protected $geocoderFormatter;
 
@@ -51,7 +51,7 @@ class AddressText extends DumperBase {
   ) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->geocoderFormatterPluginManager = $geocoder_formatter_plugin_manager;
-    $this->geocoderFormatter = $this->geocoderFormatterPluginManager->createInstance('default_geocoder_address_formatter');
+    $this->geocoderFormatter = $this->geocoderFormatterPluginManager->createInstance('default_formatted_address');
   }
 
   /**

--- a/src/Plugin/Geocoder/Formatter/FormattedAddress.php
+++ b/src/Plugin/Geocoder/Formatter/FormattedAddress.php
@@ -5,14 +5,14 @@ namespace Drupal\geocoder\Plugin\Geocoder\Formatter;
 use Geocoder\Model\Address;
 
 /**
- * Provides a Geocoder Default Formatter plugin.
+ * Provides a Default Formatted Address plugin.
  *
  * @GeocoderFormatter(
- *   id = "default_geocoder_address_formatter",
- *   name = "Default Geocoder Address Formatter"
+ *   id = "default_formatted_address",
+ *   name = "Default Formatted Address"
  * )
  */
-class GeocoderFormattedAddress extends GeocoderFormatterBase {
+class FormattedAddress extends FormatterBase {
 
   /**
    * {@inheritdoc}

--- a/src/Plugin/Geocoder/Formatter/FormatterBase.php
+++ b/src/Plugin/Geocoder/Formatter/FormatterBase.php
@@ -10,7 +10,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 /**
  * Provides a base class for geocoder formatter plugins.
  */
-abstract class GeocoderFormatterBase extends PluginBase implements GeocoderFormatterInterface, ContainerFactoryPluginInterface {
+abstract class FormatterBase extends PluginBase implements FormatterInterface, ContainerFactoryPluginInterface {
 
   /**
    * The geocoder formatter handler.

--- a/src/Plugin/Geocoder/Formatter/FormatterInterface.php
+++ b/src/Plugin/Geocoder/Formatter/FormatterInterface.php
@@ -10,7 +10,7 @@ use Geocoder\Model\Address;
  * Dumpers are plugins that knows to format geographical data into an industry
  * standard format.
  */
-interface GeocoderFormatterInterface {
+interface FormatterInterface {
 
   /**
    * Dumps the argument into a specific format.


### PR DESCRIPTION
Reverse Geocode implementation and many bug fixes and_enanchments for geocoder submodules.

Hi Pol ... here is a new/very IMPORTANT pull request, that fixes many limitations and add meaningful enhancements to the module, mainly in the geocoder_field and geocoder_geofield / geocoder_address submodules.
Sorry I couldn't split all these in single Pull Requests, and even in incremental Commits, because they are somehow interlinked and had some problems with it (don't know why, but Github was basing the Pull Request on an old state of the your actual 8.x-2.x, thus I had to re fork everything form its actual Head).
Anyway I added the synthesis of the main enhanchements embedded in this Pull Request, and can say now the Module is really start working in an amazing way, with the ability to really perform (even) combined Geocode and Reverse Geocode operations on multiple fields of the same entity.
I really invite you to try it out, with the "arcgisonline" plugin (that seems not to need an apy key out of the box), and with the Geofield and the Geofield Map (https://www.drupal.org/project/geofield_map) modules, and even with the Address module (now reallly integrated & working in this PR), both as a source of Geocode and destination of Reverse Geocode from Geofield (this wasn't working at all till now).

Just to better clarifiy and detail the Commits message, bear in mind that this PR add better logics in the Geocoder Fields implementation forcing the following: 
- Geocode method is available for DefaultField (every Dumper) and GeofieldField (forced to wkt Dumper->dump)
- Reverse Geocode method is available for DefaultField (every Dumper) and (new) AddressField (forced to geojson Dumper->dump, postprocessed to array) ONLY if Geofield & Geocoder_Geofield modules are enabled: an existing Geofield is forced to be the source/remote;
- string, text and address field types are unique sources/remote fields for Geocode Operations (not Geofield, because unresonable);
- Geofield fields types are unique sources/remote_fields for Reverse Geocode Operations (because makes sense); 

Besides this what briefly described in the (Mega) Commit message has been implemented.

Everything has been quite widley tested from me (2 - 3 days full time), and I think if merged this might be object of new alpha release.

After this, the next (and final step) I would do is implement the capability to set the Geocoder Plugins options (apikey, ssl, locale, region etc properties) that are completely missing now in the module, and that are really (really) needed to make the Geocoder Plugins somehow working in its backend Geocode/Reverse Geocode operations.
This latter implementation will bring the module state to its first Beta level.

MEGA COMMIT MESSAGE FOR MERGE

- Operative implementation of Reverse Geocode method in the geocoder_field hook_entity_presave;
- Force of better logics for source and destination field types of Geocode and Reverse Geocode capabilities:
- Add a weight element/property (in the DefaultField ContentEntityFormInterface form), and a getOrderedGeocodeFields method, to let the user define Geocode/ReverseGeocode custom order implementation;
- From the DefaultField ContentEntityFormInterface form, added the capability to disable or hide (in the Entity Insert/Edit form) the fields that are object of automatic Geocode or Reverse Geocode;
- Functional integration with the Address module with the add of the Addressfield Plugin, able to be object of Reverse Geocode from a Geofield;
- Added validation constrain and error styling (with css library) on Geocoders plugins population in the GeocoderField and GeocodeFormatter settings forms: cannot be empty;
- Add method to check/fix possible (String/Text) Field and Dumper incompatibilities , that were causing appication crash (field max-length, not UFT-8 text encoding);
- Fix of the Single to Multiple option: is valid only for Geocode (not Reverse Geocode) and will work also with multvalue source field