### PR TITLE
Better Geocode and Reverse Geocode APIs, should fetch default options from module plugins configurations. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,19 +90,22 @@ $settings['http_client_config']['proxy'];
 ```php
 $plugins = array('geonames', 'googlemaps', 'bingmaps');
 $address = '1600 Amphitheatre Parkway Mountain View, CA 94043';
-// Array of options
-// Note: At the moment options are not automatically pulled in from the module config
-$options = array(
-  'geonames' => array(), // array of options
-  'googlemaps' => array(
-    'apikey' => 'my-api-key',
-    'usessl' => TRUE,
-  ),
-  'bingmaps' => array(), // array of options
-);
+
+// Array of (ovverriding) options (@see Note* below)
+$options = [
+  'freegeoip' => [], // array of options
+  'geonames' => [], // array of options
+  'googlemaps' => [], // array of options
+  'bingmaps' => [], // array of options
+];
 
 $addressCollection = \Drupal::service('geocoder')->geocode($address, $plugins, $options);
+
+Note*: The last $options array parameter is optional, and merges/overrides the default plugins options set in the module configurations, that will be used normally as defaults.
+
 ```
+
+####Note
 
 ## Reverse geocode coordinates
 
@@ -110,16 +113,19 @@ $addressCollection = \Drupal::service('geocoder')->geocode($address, $plugins, $
 $plugins = array('freegeoip', 'geonames', 'googlemaps', 'bingmaps');
 $lat = '37.422782';
 $lon = '-122.085099';
-// Array of options
-// Note: At the moment options are not automatically pulled in from the module config.
-$options = array(
-  'freegeoip' => array(), // array of options
-  'geonames' => array(), // array of options
-  'googlemaps' => array(), // array of options
-  'bingmaps' => array(), // array of options
-);
+
+// Array of (ovverriding) options (@see Note* below)
+$options = [
+  'freegeoip' => [], // array of options
+  'geonames' => [], // array of options
+  'googlemaps' => [], // array of options
+  'bingmaps' => [], // array of options
+];
 
 $addressCollection = \Drupal::service('geocoder')->reverse($lat, $lon, $plugins, $options);
+
+Note*: The last $options array parameter is optional, and merges/overrides the default plugins options set in the module configurations, that will be used normally as defaults.
+
 ```
 
 ## Return format
@@ -133,13 +139,8 @@ You can transform those objects into arrays. Example:
 ```php
 $plugins = array('geonames', 'googlemaps', 'bingmaps');
 $address = '1600 Amphitheatre Parkway Mountain View, CA 94043';
-$options = array(
-  'geonames' => array(), // array of options
-  'googlemaps' => array(), // array of options
-  'bingmaps' => array(), // array of options
-);
 
-$addressCollection = \Drupal::service('geocoder')->geocode($address, $plugins, $options);
+$addressCollection = \Drupal::service('geocoder')->geocode($address, $plugins);
 $address_array = $addressCollection->first()->toArray();
 
 // You can play a bit more with the API
@@ -161,13 +162,8 @@ Here's an example on how to use a Dumper:
 ```php
 $plugins = array('geonames', 'googlemaps', 'bingmaps'); 
 $address = '1600 Amphitheatre Parkway Mountain View, CA 94043';
-$options = array(
-  'geonames' => array(), // array of options
-  'googlemaps' => array(), // array of options
-  'bingmaps' => array(), // array of options
-);
 
-$addressCollection = \Drupal::service('geocoder')->geocode($address, $plugins, $options);
+$addressCollection = \Drupal::service('geocoder')->geocode($address, $plugins);
 $geojson = \Drupal::service('plugin.manager.geocoder.dumper')->createInstance('geojson')->dump($addressCollection->first());
 ```
 
@@ -176,13 +172,8 @@ There's also a dumper for GeoPHP, here's how to use it:
 ```php
 $plugins = array('geonames', 'googlemaps', 'bingmaps');
 $address = '1600 Amphitheatre Parkway Mountain View, CA 94043';
-$options = array(
-  'geonames' => array(), // array of options
-  'googlemaps' => array(), // array of options
-  'bingmaps' => array(), // array of options
-);
 
-$addressCollection = \Drupal::service('geocoder')->geocode($address, $plugins, $options);
+$addressCollection = \Drupal::service('geocoder')->geocode($address, $plugins);
 $geometry = \Drupal::service('plugin.manager.geocoder.dumper')->createInstance('geometry')->dump($addressCollection->first());
 ```
 

--- a/geocoder.services.yml
+++ b/geocoder.services.yml
@@ -2,7 +2,7 @@ services:
 
   geocoder:
     class: Drupal\geocoder\Geocoder
-    arguments: ['@plugin.manager.geocoder.provider']
+    arguments: ['@config.factory','@plugin.manager.geocoder.provider']
 
   geocoder.http_adapter:
     class: Drupal\geocoder\GeocoderHttpAdapter

--- a/modules/geocoder_address/src/Plugin/Field/FieldFormatter/AddressGeocodeFormatter.php
+++ b/modules/geocoder_address/src/Plugin/Field/FieldFormatter/AddressGeocodeFormatter.php
@@ -25,7 +25,6 @@ class AddressGeocodeFormatter extends GeocodeFormatter {
     $elements = [];
     $dumper = $this->dumperPluginManager->createInstance($this->getSetting('dumper'));
     $provider_plugins = $this->getEnabledProviderPlugins();
-    $geocoder_plugins_options = (array) $this->config->get('plugins_options');
 
     foreach ($items as $delta => $item) {
       $value = $item->getValue();
@@ -37,7 +36,7 @@ class AddressGeocodeFormatter extends GeocodeFormatter {
       $address[] = !empty($value['locality']) ? $value['locality'] : NULL;
       $address[] = !empty($value['country']) ? $value['country'] : NULL;
 
-      if ($addressCollection = $this->geocoder->geocode(implode(' ', array_filter($address)), array_keys($provider_plugins), $geocoder_plugins_options)) {
+      if ($addressCollection = $this->geocoder->geocode(implode(' ', array_filter($address)), array_keys($provider_plugins))) {
         $elements[$delta] = [
           '#plain_text' => $dumper->dump($addressCollection->first()),
         ];

--- a/modules/geocoder_field/geocoder_field.module
+++ b/modules/geocoder_field/geocoder_field.module
@@ -137,9 +137,6 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
   /** @var \Drupal\geocoder\DumperPluginManager $dumper_manager */
   $dumper_manager = \Drupal::service('plugin.manager.geocoder.dumper');
 
-  $geocoder_config = \Drupal::configFactory()->get('geocoder.settings');
-  $geocoder_plugins_options = (array) $geocoder_config->get('plugins_options');
-
   // Reorder the list of fields to be Geocoded | Reverse Geocoded.
   $order_geocoder_fields = $preprocessor_manager->getOrderedGeocodeFields($entity);
 
@@ -209,12 +206,12 @@ function geocoder_field_entity_presave(EntityInterface $entity) {
         switch ($geocoder['method']) {
           case 'source':
             $failure_status_message = t("Unable to geocode '@text'.", ['@text' => isset($value['value']) ? $value['value'] : '']);
-            $address_collection = isset($value['value']) ? \Drupal::service('geocoder')->geocode($value['value'], $geocoder['plugins'], $geocoder_plugins_options) : NULL;
+            $address_collection = isset($value['value']) ? \Drupal::service('geocoder')->geocode($value['value'], $geocoder['plugins']) : NULL;
             break;
 
           case 'destination':
             $failure_status_message = t("Unable to reverse geocode the <em>@field_name</em> value.", ['@field_name' => $field_name]);
-            $address_collection = isset($value['lat']) && isset($value['lon']) ? \Drupal::service('geocoder')->reverse($value['lat'], $value['lon'], $geocoder['plugins'], $geocoder_plugins_options) : NULL;
+            $address_collection = isset($value['lat']) && isset($value['lon']) ? \Drupal::service('geocoder')->reverse($value['lat'], $value['lon'], $geocoder['plugins']) : NULL;
             break;
 
           default:

--- a/modules/geocoder_field/src/Plugin/Field/GeocodeFormatterBase.php
+++ b/modules/geocoder_field/src/Plugin/Field/GeocodeFormatterBase.php
@@ -217,10 +217,9 @@ abstract class GeocodeFormatterBase extends FormatterBase implements ContainerFa
     $elements = [];
     $dumper = $this->dumperPluginManager->createInstance($this->getSetting('dumper'));
     $provider_plugins = $this->getEnabledProviderPlugins();
-    $geocoder_plugins_options = (array) $this->config->get('plugins_options');
 
     foreach ($items as $delta => $item) {
-      if ($address_collection = $this->geocoder->geocode($item->value, array_keys($provider_plugins), $geocoder_plugins_options)) {
+      if ($address_collection = $this->geocoder->geocode($item->value, array_keys($provider_plugins))) {
         $elements[$delta] = [
           '#plain_text' => $dumper->dump($address_collection->first()),
         ];

--- a/modules/geocoder_geofield/src/Plugin/Field/FieldFormatter/ReverseGeocodeGeofieldFormatter.php
+++ b/modules/geocoder_geofield/src/Plugin/Field/FieldFormatter/ReverseGeocodeGeofieldFormatter.php
@@ -25,7 +25,6 @@ class ReverseGeocodeGeofieldFormatter extends GeocodeFormatterBase {
     $elements = [];
     $dumper = $this->dumperPluginManager->createInstance($this->getSetting('dumper'));
     $provider_plugins = $this->getEnabledProviderPlugins();
-    $geocoder_plugins_options = (array) $this->config->get('plugins_options');
 
     /** @var \Drupal\geofield\GeoPHP\GeoPHPInterface $geophp */
     $geophp = \Drupal::service('geofield.geophp');
@@ -37,7 +36,7 @@ class ReverseGeocodeGeofieldFormatter extends GeocodeFormatterBase {
       /** @var \Point $centroid */
       $centroid = $geom->getCentroid();
 
-      if ($address_collection = $this->geocoder->reverse($centroid->y(), $centroid->x(), array_keys($provider_plugins), $geocoder_plugins_options)) {
+      if ($address_collection = $this->geocoder->reverse($centroid->y(), $centroid->x(), array_keys($provider_plugins))) {
         $elements[$delta] = [
           '#markup' => $dumper->dump($address_collection->first()),
         ];

--- a/src/Geocoder.php
+++ b/src/Geocoder.php
@@ -2,12 +2,22 @@
 
 namespace Drupal\geocoder;
 
+use Drupal\Component\Utility\NestedArray;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Geocoder\Exception\InvalidCredentials;
 
 /**
  * Provides a geocoder factory class.
  */
 class Geocoder implements GeocoderInterface {
+
+  /**
+   * The config factory service.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $config;
+
 
   /**
    * The geocoder provider plugin manager service.
@@ -19,10 +29,13 @@ class Geocoder implements GeocoderInterface {
   /**
    * Constructs a geocoder factory class.
    *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   A config factory for retrieving required config objects.
    * @param \Drupal\geocoder\ProviderPluginManager $provider_plugin_manager
    *   The geocoder provider plugin manager service.
    */
-  public function __construct(ProviderPluginManager $provider_plugin_manager) {
+  public function __construct(ConfigFactoryInterface $config_factory, ProviderPluginManager $provider_plugin_manager) {
+    $this->config = $config_factory->get('geocoder.settings');
     $this->providerPluginManager = $provider_plugin_manager;
   }
 
@@ -30,9 +43,15 @@ class Geocoder implements GeocoderInterface {
    * {@inheritdoc}
    */
   public function geocode($data, array $plugins, array $options = []) {
+
+    // Retrieve plugins options from the module configurations.
+    $plugins_options = $this->config->get('plugins_options');
+
+    // Merge possible options overrides into plugins options.
+    $plugins_options = NestedArray::mergeDeep($plugins_options, $options);
+
     foreach ($plugins as $plugin_id) {
-      $options += [$plugin_id => []];
-      $provider = $this->providerPluginManager->createInstance($plugin_id, $options[$plugin_id]);
+      $provider = $this->providerPluginManager->createInstance($plugin_id, $plugins_options[$plugin_id]);
 
       try {
         return $provider->geocode($data);
@@ -52,9 +71,15 @@ class Geocoder implements GeocoderInterface {
    * {@inheritdoc}
    */
   public function reverse($latitude, $longitude, array $plugins, array $options = []) {
+
+    // Retrieve plugins options from the module configurations.
+    $plugins_options = $this->config->get('plugins_options');
+
+    // Merge possible options overrides into plugins options.
+    $plugins_options = NestedArray::mergeDeep($plugins_options, $options);
+
     foreach ($plugins as $plugin_id) {
-      $options += [$plugin_id => []];
-      $provider = $this->providerPluginManager->createInstance($plugin_id, $options[$plugin_id]);
+      $provider = $this->providerPluginManager->createInstance($plugin_id, $plugins_options[$plugin_id]);
 
       try {
         return $provider->reverse($latitude, $longitude);

--- a/src/GeocoderInterface.php
+++ b/src/GeocoderInterface.php
@@ -16,10 +16,11 @@ interface GeocoderInterface {
    *   A list of plugin identifiers to use.
    * @param array $options
    *   (optional) An associative array with plugin options, keyed plugin by the
-   *   plugin id. Defaults to an empty array.
+   *   plugin id. Defaults to an empty array. These options would be merged with
+   *   (and would override) plugins options set in the module configurations.
    *
    * @return \Geocoder\Model\AddressCollection|null
-   *   An address collection or NULL on gecoding failure.
+   *   An address collection or NULL on geocoding failure.
    */
   public function geocode($data, array $plugins, array $options = []);
 
@@ -34,7 +35,8 @@ interface GeocoderInterface {
    *   A list of plugin identifiers to use.
    * @param array $options
    *   (optional) An associative array with plugin options, keyed plugin by the
-   *   plugin id. Defaults to an empty array.
+   *   plugin id. Defaults to an empty array. These options would be merged with
+   *   (and would override) plugins options set in the module configurations.
    *
    * @return \Geocoder\Model\AddressCollection|null
    *   An address collection or NULL on gecoding failure.


### PR DESCRIPTION
This refactoring relates to this Geocoder open issue: 
https://www.drupal.org/project/geocoder/issues/3000444

As araised from this related issue: https://www.drupal.org/project/geocoder/issues/2955125
geocode and reverse methods in the Geocoder services could (and really should) fetch the plugin options (as default values) from the correspondent Drupal configurations (geocoder.settings.plugins_options). The methods third parameter ($options) might be used as possible & manual overrides in the APIs.

This PR accomplish a better refactoring of the Geocoder Service for what concerns its main (geocode and reverse) methods, and all their invocations in the module itseself and its submodules.

Readme.md documentation has been updated accordingly.

**Everything has been tested by me operatively, with real geocoding and reverse geocoding operations, both in the entity_presave and in the geocoder formatters. Everything (it seems) works fine and no regression came out.**

PS: Once this PR has been approved and committed into dev, a similar will subsequentally packed and forwarded to be merged into 8.x-3.x.